### PR TITLE
Adds support for FreeBSD 12.1 and setting up as a VMWare guest.

### DIFF
--- a/bin/instant-workstation
+++ b/bin/instant-workstation
@@ -147,7 +147,7 @@ then
 fi
 if test -n "$sysctl"
 then
-	command="$command ; /sbin/sysctl -f /etc/sysctl.conf $sysctl";
+	command="$command ; /usr/sbin/sysrc -f /etc/sysctl.conf $sysctl";
 fi
 
 su root -c "$command"

--- a/bin/instant-workstation
+++ b/bin/instant-workstation
@@ -94,7 +94,7 @@ vga_vendor=$( /usr/sbin/pciconf -l | /usr/bin/awk '/^vgapci/{ print substr($4,8,
 if test 8086 = "${vga_product}"
 then
 	case "x${fbsd_version}" in
-		"x12.0")
+		"x12.0"|"x12.1")
 			packages="$packages graphics/drm-fbsd12.0-kmod"
 			;;
 		"x11.2")
@@ -114,6 +114,16 @@ then
 	# Virtualbox Support
 	packages="$packages emulators/virtualbox-ose-additions"
 	sysrc="$sysrc vboxguest_enable=YES vboxservice_enable=YES"
+fi
+
+### VMWARE
+#
+#
+if test 0405 = "${vga_vendor}"
+then
+	# VMWare Workstation Support
+	packages="$packages open-vm-tools xf86-input-vmmouse xf86-video-vmware"
+	sysrc="$sysrc dbus_enable=YES moused_enable=YES vmware_guest_vmblock_enable=YES vmware_guest_vmhgfs_enable=YES vmware_guest_vmmemctl_enable=YES vmware_guest_vmxnet_enable=YES vmware_guestd_enable=YES"
 fi
 
 ### X11
@@ -137,7 +147,39 @@ then
 fi
 if test -n "$sysctl"
 then
-	command="$command ; /usr/sbin/sysrc -f /etc/sysctl.conf $sysctl";
+	command="$command ; /sbin/sysctl -f /etc/sysctl.conf $sysctl";
 fi
 
+echo $command
 su root -c "$command"
+
+### VMWARE Post installation
+#
+#
+if test 0405 = "${vga_vendor}"
+then
+	echo 'Updating vmware X configuration'
+	mkdir -p /usr/local/etc/X11/xorg.conf.d
+	
+	# X11 configuration
+	echo '# Temporary fix to set vmmouse
+	Section "ServerFlags"
+		Option     "AutoAddDevices" "false"
+	EndSection
+	
+	Section "InputDevice"
+		Identifier "Mouse0"
+		Driver     "vmmouse"
+		Option     "Device" "/dev/sysmouse"
+	EndSection
+	
+	Section "Device"
+		Identifier "Card0"
+		Driver     "vmware"
+	EndSection' > /usr/local/etc/X11/xorg.conf.d/vmware.conf
+
+	# Enable 3D acceleration when available
+	echo 'To enable 3D acceleration, add your username(s) to the ''video'' group with:'
+	echo '    pw groupmod video -m <username>'
+fi
+

--- a/bin/instant-workstation
+++ b/bin/instant-workstation
@@ -150,7 +150,6 @@ then
 	command="$command ; /sbin/sysctl -f /etc/sysctl.conf $sysctl";
 fi
 
-echo $command
 su root -c "$command"
 
 ### VMWARE Post installation


### PR DESCRIPTION
Also adds a bugfix for using sysctl instead of sysrc for the net.local.stream settings required by KDE. (Not sure if this is new with 12.1?). Glad to make changes you see fit, and no worries if this isn't something you don't want to include.

Thank you for your consideration, and for creating this script in the first place!